### PR TITLE
Revert "wrong archiveinterface modules"

### DIFF
--- a/sphinx/archiveinterface.archiveinterface.tests.rst
+++ b/sphinx/archiveinterface.archiveinterface.tests.rst
@@ -3,14 +3,14 @@ Archivebackends Module
 
 Contents:
  
-.. automodule:: archiveinterface.archiveinterface.tests.archive_interface_unit_test
+.. automodule:: archiveinterface.tests.archive_interface_unit_test
    :members:
    :private-members:
 
-.. automodule:: archiveinterface.archiveinterface.tests.archive_posix_unit_test
+.. automodule:: archiveinterface.tests.archive_posix_unit_test
    :members:
    :private-members:
 
-.. automodule:: archiveinterface.archiveinterface.tests.archive_response_unit_test
+.. automodule:: archiveinterface.tests.archive_response_unit_test
    :members:
    :private-members:


### PR DESCRIPTION
Reverts pacifica/pacifica-docs#10